### PR TITLE
Added extrinsic calibration transform T_sv (sensor, vehicle)

### DIFF
--- a/config/steam.json
+++ b/config/steam.json
@@ -37,7 +37,8 @@
         "log_det_topk": 20,
         "use_ransac": false,
         "ransac_version": 0,
-        "use_ctsteam": false
+        "use_ctsteam": false,
+        "ex_translation_vs_in_s": [-1.03, 0, 0]
     },
     "lr": 0.00001,
     "weight_decay": 0,

--- a/cpp/SteamSolver.hpp
+++ b/cpp/SteamSolver.hpp
@@ -16,6 +16,10 @@ public:
                    0.0021394075786459413462958778495704;
         Qc_inv_.setZero();
         Qc_inv_.diagonal() = 1.0/Qc_diag;
+
+        // Initialize extrinsic transform to identity
+        T_sv_ = steam::se3::FixedTransformEvaluator::MakeShared(lgmath::se3::Transformation());
+
         // Initialize trajectory
         resetTraj();
     }
@@ -25,12 +29,13 @@ public:
     void setQcInv(const np::ndarray& Qc_diag);
     void setMeas(const p::object& p2_list, const p::object& p1_list, const p::object& weight_list,
         const p::object& t2_list, const p::object& t1_list, const p::object& t_refs);
+    void setExtrinsicTsv(const np::ndarray& T_sv);
     // solve
     void optimize();
     // output
     void getPoses(np::ndarray& poses);
     void getVelocities(np::ndarray& vels);
-    void getSigmapoints2NP1(np::ndarray& sigma_T);
+    void getSigmapoints2N(np::ndarray& sigma_T);
     void useRansac() {use_ransac = true;}
     void setRansacVersion(const unsigned int& version) {ransac_version = uint(version);}
     void useCTSteam() {ct_steam = true;}
@@ -53,6 +58,7 @@ private:
     double dt_ = 0.25;  // trajectory time step
     unsigned int window_size_ = 2;  // trajectory window size
     Eigen::Matrix<double, 6, 6> Qc_inv_;  // Motion prior inverse Qc
+    steam::se3::TransformEvaluator::Ptr T_sv_;
     // RANSAC
     bool use_ransac = false;
     unsigned int ransac_version = 0;
@@ -68,11 +74,12 @@ BOOST_PYTHON_MODULE(SteamSolver) {
         .def("slideTraj", &SteamSolver::slideTraj)
         .def("setQcInv", &SteamSolver::setQcInv)
         .def("setMeas", &SteamSolver::setMeas)
+        .def("setExtrinsicTsv", &SteamSolver::setExtrinsicTsv)
         .def("optimize", &SteamSolver::optimize)
         .def("getPoses", &SteamSolver::getPoses)
         .def("getVelocities", &SteamSolver::getVelocities)
         .def("useRansac", &SteamSolver::useRansac)
         .def("setRansacVersion", &SteamSolver::setRansacVersion)
         .def("useCTSteam", &SteamSolver::useCTSteam)
-        .def("getSigmapoints2NP1", &SteamSolver::getSigmapoints2NP1);
+        .def("getSigmapoints2N", &SteamSolver::getSigmapoints2N);
 }

--- a/networks/steam_solver.py
+++ b/networks/steam_solver.py
@@ -38,6 +38,10 @@ class SteamSolver():
         if config['steam']['use_ctsteam']:
             self.solver_cpp.useCTSteam()
         self.sigmapoints_flag = (config['steam']['expect_approx_opt'] == 1)
+        T_sv = np.eye(4, dtype=np.float32)
+        for i in range(3):  # set translation component of T_sv = [C_sv r_vs_in_s]
+            T_sv[i, 3] = config['steam']['ex_translation_vs_in_s'][i]
+        self.solver_cpp.setExtrinsicTsv(T_sv)
 
     def optimize(self, keypoint_coords, pseudo_coords, match_weights, keypoint_ints, time_tgt, time_src):
         """
@@ -108,7 +112,7 @@ class SteamSolver():
             self.solver_cpp.getVelocities(self.vels[b])
             # sigmapoints output
             if self.sigmapoints_flag:
-                self.solver_cpp.getSigmapoints2NP1(self.poses_sp[b])
+                self.solver_cpp.getSigmapoints2N(self.poses_sp[b])
             # set output
             R_tgt_src[b] = self.poses[b, :, :3, :3]
             t_src_tgt_in_tgt[b] = self.poses[b, :, :3, 3:4]


### PR DESCRIPTION
- Currently we set only the translation component of T_sv through config (ex_translation_vs_in_s). Can easily add rotation, e.g., we can get rid of the flip_y and incorporate it into T_sv.
- ex_translation_vs_in_s currently set to [-1.03, 0, 0] based on diagram on oxford dataset webpage to put vehicle frame at the center of rear axle (where SPAN-CPT is located).
- Mostly changes to steam code. Output of steam (getPose) gives sensor pose estimates, so no change necessary to python code.
- Also changed function name getSigmapoints2NP1 to getSigmapoints2N since it yields 2*N points, not 2*N + 1 points.